### PR TITLE
Trace average FPS a) from start-to-finish of each song and b) every f…

### DIFF
--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
@@ -345,6 +345,18 @@ namespace DTXMania
 				#region [ 初めての進行描画 ]
 				if ( base.b初めての進行描画 )
 				{
+
+
+
+					// Initialize average FPS stats collection
+					CDTXMania.FPS.GetAndResetAverageFpsSinceLastReset();
+					bHasFinishedPlaying = false;
+					bHasFinishedEndAnime = false;
+					bHasFinishedFadeout = false;
+					Trace.TraceInformation("Average FPS calculation initialized.");
+
+
+
                     CSound管理.rc演奏用タイマ.tリセット();
 					CDTXMania.Timer.tリセット();
 					this.ctチップ模様アニメ.Drums = new CCounter( 0, 1, 500, CDTXMania.Timer );
@@ -549,12 +561,45 @@ namespace DTXMania
                 // 確認用 18_04_26(AioiLight)
                 //CDTXMania.act文字コンソール.tPrint(0, 0, C文字コンソール.Eフォント種別.白, this.actGauge.db現在のゲージ値[0].ToString());
 
+
+
+				// Trace and reset average FPS stats collection when one of the following becomes true for the first time
+				if (bHasFinishedPlaying ^ bIsFinishedPlaying ||
+					bHasFinishedEndAnime ^ bIsFinishedEndAnime ||
+					bHasFinishedFadeout ^ bIsFinishedFadeout)
+				{
+					bHasFinishedPlaying |= bIsFinishedPlaying;
+					bHasFinishedEndAnime |= bIsFinishedEndAnime;
+					bHasFinishedFadeout |= bIsFinishedFadeout;
+
+					var results = CDTXMania.FPS.GetAndResetAverageFpsSinceLastReset();
+					Trace.TraceInformation("Average FPS: {0} (bIsFinishedPlaying = {1}, bIsFinishedEndAnime = {2}, bIsFinishedFadeout = {3})",
+						results.AverageFpsSinceLastReset, bIsFinishedPlaying, bIsFinishedEndAnime, bIsFinishedFadeout);
+					var sb = new StringBuilder();
+					foreach (var averageFps in results.AverageFpsAtReportingIntervalsSinceLastReset)
+					{
+						sb.Append($"{averageFps},");
+					}
+					Trace.TraceInformation("Average FPS between reporting intervals: {0}", sb.ToString());
+				}
+
+
+
             }
             base.sw.Stop();
 			return 0;
 		}
 
 		// その他
+
+
+
+		// Average FPS stats support fields
+		private bool bHasFinishedPlaying;
+		private bool bHasFinishedEndAnime;
+		private bool bHasFinishedFadeout;
+
+
 
 		#region [ private ]
 		//-----------------

--- a/FDK17プロジェクト/コード/00.共通/CFPS.cs
+++ b/FDK17プロジェクト/コード/00.共通/CFPS.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace FDK
 {
@@ -13,43 +12,60 @@ namespace FDK
 			get;
 			private set;
 		}
-		public bool bFPSの値が変化した
-		{
-			get;
-			private set;
-		}
-
 
 		// コンストラクタ
 
 		public CFPS()
 		{
 			this.n現在のFPS = 0;
-			this.timer = new CTimer( CTimer.E種別.MultiMedia );
-			this.基点時刻ms = this.timer.n現在時刻;
-			this.内部FPS = 0;
-			this.bFPSの値が変化した = false;
+			this.timer = new CTimer(CTimer.E種別.MultiMedia);
+
+			StartNewReportingInterval();
+
+			_baseTimeAtLastReset = this.基点時刻ms;
+			_updatesSinceLastReset = 0;
 		}
 
+		private void StartNewReportingInterval()
+		{
+			this.基点時刻ms = this.timer.n現在時刻;
+			this._updatesSinceLastReportingInterval = 0;
+		}
 
 		// メソッド
 
 		public void tカウンタ更新()
 		{
 			this.timer.t更新();
-			this.bFPSの値が変化した = false;
+			this._updatesSinceLastReportingInterval++;
+			this._updatesSinceLastReset++;
 
-			const long INTERVAL = 1000;
-			while( ( this.timer.n現在時刻 - this.基点時刻ms ) >= INTERVAL )
+			const double REPORTING_INVERVAL_MS = 5000;
+			var interval = this.timer.n現在時刻 - this.基点時刻ms;
+			if (REPORTING_INVERVAL_MS <= interval)
 			{
-				this.n現在のFPS = this.内部FPS;
-				this.内部FPS = 0;
-				this.bFPSの値が変化した = true;
-				this.基点時刻ms += INTERVAL;
+				this.n現在のFPS = (int)(_updatesSinceLastReportingInterval / (interval / 1000.0));
+				_averageFpsAtReportingIntervalsSinceLastReset.Add(this.n現在のFPS); 
+				StartNewReportingInterval();
 			}
-			this.内部FPS++;
 		}
 
+		public AverageFpsInformation GetAndResetAverageFpsSinceLastReset()
+		{
+			long n現在時刻 = this.timer.n現在時刻;
+			var interval = n現在時刻 - _baseTimeAtLastReset;
+
+			var averageFpsSinceLastReset = (int)(_updatesSinceLastReset / (interval / 1000.0));
+
+			// old-school copy for .net 3.5 until upgrade
+			var averageFpsAtReportingIntervalsSinceLastReset = new int[_averageFpsAtReportingIntervalsSinceLastReset.Count];
+			_averageFpsAtReportingIntervalsSinceLastReset.CopyTo(averageFpsAtReportingIntervalsSinceLastReset);
+
+			_baseTimeAtLastReset = n現在時刻;
+			_updatesSinceLastReset = 0;
+			_averageFpsAtReportingIntervalsSinceLastReset.Clear();
+			return new AverageFpsInformation(averageFpsSinceLastReset, averageFpsAtReportingIntervalsSinceLastReset);
+		}
 
 		// その他
 
@@ -57,7 +73,23 @@ namespace FDK
 		//-----------------
 		private CTimer	timer;
 		private long	基点時刻ms;
-		private int		内部FPS;
+		private long	_updatesSinceLastReportingInterval;
+		private long	_baseTimeAtLastReset;
+		private long _updatesSinceLastReset;
+		private List<int> _averageFpsAtReportingIntervalsSinceLastReset = new List<int>();
+
+		public class AverageFpsInformation
+		{
+			public int AverageFpsSinceLastReset { get; }
+			public int[] AverageFpsAtReportingIntervalsSinceLastReset { get; }
+
+			public AverageFpsInformation(int averageFpsSinceLastReset, int[] averageFpsAtReportingIntervalsSinceLastReset)
+			{
+				AverageFpsSinceLastReset = averageFpsSinceLastReset;
+				AverageFpsAtReportingIntervalsSinceLastReset = averageFpsAtReportingIntervalsSinceLastReset;
+			}
+		}
+
 		//-----------------
 		#endregion
 	}


### PR DESCRIPTION
…ive seconds during each song.

This also includes a simpler FPS calculation than was previously there. This code should be mined for that logic, as it is a cleaner implementation for use even when not collecting average FPS stats or, for example, when only collecting them for each song as a whole but without the every-five-seconds variation.